### PR TITLE
Fixed bug with Prod EU

### DIFF
--- a/scripts/target_new_environment
+++ b/scripts/target_new_environment
@@ -45,7 +45,7 @@ select environment in "Prod-US" "Prod-EU" "Sandbox" "Localhost"; do
 			break;;
 		Prod-EU )
 			URL="https://api.eu.clover.com/"
-			TARGET="prod-eu"
+			TARGET="prod_eu"
 			break;;
 		Sandbox )
 			URL="https://apisandbox.dev.clover.com/"


### PR DESCRIPTION
Changing the 'clover_cloud_target' to 'prod-eu' breaks it! The correct and working value should be 'prod_eu'.
