### PR TITLE
Hotfix for r293 build issues

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 
 repositories {
   mavenLocal()
-  maven {url "https://artifactory.corp.clover.com/artifactory/repo"}
+  mavenCentral()
   google()
 }
 


### PR DESCRIPTION
Replaces an invalid repo link with mavenCentral to resolve issues with building.